### PR TITLE
fix: Don't blow up if `apt/lists/` doesn't exist

### DIFF
--- a/extras.dockerfile
+++ b/extras.dockerfile
@@ -17,7 +17,7 @@ FROM $USER_BASE_IMG
 ARG UID
 ARG USER
 
-RUN rm -r /var/lib/apt/lists/* \
+RUN rm -rf /var/lib/apt/lists/* \
     && dpkg --clear-avail \
     && apt-get update -q \
     && apt-get install -y --no-install-recommends \
@@ -47,7 +47,7 @@ RUN rm -r /var/lib/apt/lists/* \
 # apt-get block
 
 RUN dpkg --clear-avail \
-    && rm -r /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/* \
     && apt-get update -q \
     && apt-get install -y --no-install-recommends \
         # Add more dependencies here


### PR DESCRIPTION
Just a trivial fix from my hackage relating to SEL4PROJ/seL4-CAmkES-L4v-dockerfiles#15